### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Deploys Sphinx Docs to Github Pages
+# Deploys Sphinx Docs to Github Pages via a branch
 
 name: docs
 

--- a/.github/workflows/docs_rust.yaml
+++ b/.github/workflows/docs_rust.yaml
@@ -1,10 +1,14 @@
+# Deploys Cargo/Rust docs via Github Actions
+# Unused until there's a way to mix with Python docs
+
 name: Documentation
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_dispatch: # Currently disabled unless manually ran
+  # pull_request:
+  # push:
+  #   branches:
+  #     - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Previously the docs published is the Rust/Cargo docs. This PR changes to the Python API's docs, as it makes more sense from a user perspective.