### PR TITLE
Make pytest not take in an optimization level argument

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run Pytest
         run: |
           pytest -v tests/ --cov=python2verilog/ --cov-report term-missing \
-          --write -L 0 1 2 -Iextern/iverilog/driver/iverilog
+          --write -L 2 -Iextern/iverilog/driver/iverilog
 
   quick:
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
         run: |
           pytest -v tests/ --cov=python2verilog/ --cov-report term-missing
           pytest -v tests/ --cov=python2verilog/ --cov-report term-missing \
-          --write --synthesis --optimization-levels 0 1 2
+          --write --synthesis -L 2
 
   full:
     runs-on: ubuntu-latest
@@ -90,7 +90,6 @@ jobs:
       fail-fast: false
       matrix:
         pytest-args: ["", "-RS", "-FRS", "-F"]
-        pytest-opti-levels: ["-L 0 1 2 4 8"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -118,7 +117,7 @@ jobs:
       - name: Run Pytest
         run: |
           pytest tests/ --cov=python2verilog/ --cov-report term-missing \
-          ${{ matrix.pytest-args }} ${{ matrix.pytest-opti-levels }}
+          ${{ matrix.pytest-args }} -L 16
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ params = [
         "first_test",
         default=False,
         action="store_true",
-        help="Set to only run first case in each test",
+        help="Set to only run the first test case (arguments for function) in each integration test",
     ),
     Argument(
         "R",
@@ -38,7 +38,7 @@ params = [
         default=2,
         type=int,
         action="store",
-        help="Limit optimization level to run tests on",
+        help="Limit optimization levels being tested to those less than or equal to this value",
     ),
     Argument(
         "I",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,12 +34,11 @@ params = [
     ),
     Argument(
         "L",
-        "optimization_levels",
-        default=[],
-        nargs="+",
+        "optimization_level_limit",
+        default=2,
         type=int,
-        action="extend",
-        help="Set which optimization levels tests run on",
+        action="store",
+        help="Limit optimization level to run tests on",
     ),
     Argument(
         "I",
@@ -83,11 +82,8 @@ def argparse(request):
     for param in params:
         args[param.name] = request.config.getoption(f"--{param.dashed_name}")
 
-    args["optimization_levels"] = (
-        set(args["optimization_levels"]) if args["optimization_levels"] else {1}
-    )
     sys.setrecursionlimit(
-        sys.getrecursionlimit() + max(args["optimization_levels"]) * 250
+        sys.getrecursionlimit() + args["optimization_level_limit"] * 250
     )
     env.set_var(env.Vars.IVERILOG_PATH, args["iverilog_path"])
     if args["synthesis"]:

--- a/tests/integration/base_tests.py
+++ b/tests/integration/base_tests.py
@@ -52,7 +52,10 @@ class BaseTestWrapper:
                 test_cases = [next(iter(test_cases))]
             test_cases = list(map(make_tuple, test_cases))
 
-            for opti_level in self.args.optimization_levels:
+            for opti_level in test_param.opti_levels:
+                if opti_level > self.args.optimization_level_limit:
+                    continue
+
                 ns = {}
 
                 for func in reversed(funcs):  # First function is tested upon

--- a/tests/integration/base_tests.py
+++ b/tests/integration/base_tests.py
@@ -8,8 +8,6 @@ import re
 import subprocess
 import unittest
 from pathlib import Path
-from types import FunctionType
-from typing import Iterable, Union
 
 import pandas as pd
 
@@ -26,7 +24,7 @@ from python2verilog.backend.verilog.config import CodegenConfig
 from python2verilog.simulation import iverilog
 from python2verilog.simulation.display import strip_ready, strip_valid
 
-from .utils import make_tuple
+from .utils import Parameters, make_tuple
 
 
 class BaseTestWrapper:
@@ -41,13 +39,14 @@ class BaseTestWrapper:
 
         def __test(
             self,
-            funcs: Union[Iterable[FunctionType], FunctionType],
-            test_cases: Iterable[Union[tuple[int, ...], int]],
+            test_param: Parameters,
             config: CodegenConfig,
         ):
             """
             Root test function
             """
+            funcs = [test_param.func]
+            test_cases = test_param.args_list
 
             if self.args.first_test:
                 test_cases = [next(iter(test_cases))]
@@ -186,26 +185,24 @@ class BaseTestWrapper:
 
         def test_perf(
             self,
-            funcs: Union[Iterable[FunctionType], FunctionType],
-            test_cases: Iterable[Union[tuple[int, ...], int]],
+            test_param: Parameters,
         ):
             """
             Performance test
             Does max-clock cycle checks
             The caller is always ready to receive data
             """
-            self.__test(funcs, test_cases, CodegenConfig(random_ready=False))
+            self.__test(test_param, CodegenConfig(random_ready=False))
 
         def test_correct(
             self,
-            funcs: Union[Iterable[FunctionType], FunctionType],
-            test_cases: Iterable[Union[tuple[int, ...], int]],
+            test_param: Parameters,
         ):
             """
             Correctness test
             The caller is not always ready to receive data
             """
-            self.__test(funcs, test_cases, CodegenConfig(random_ready=True))
+            self.__test(test_param, CodegenConfig(random_ready=True))
 
         @staticmethod
         def make_statistics(cls):

--- a/tests/integration/base_tests.py
+++ b/tests/integration/base_tests.py
@@ -2,7 +2,6 @@
 Base classes for integration tests
 """
 
-import dataclasses
 import logging
 import os
 import re
@@ -28,25 +27,6 @@ from python2verilog.simulation import iverilog
 from python2verilog.simulation.display import strip_ready, strip_valid
 
 from .utils import make_tuple
-
-
-@dataclasses.dataclass
-class TestParameters:
-    # Function to-be-tested
-    func: FunctionType
-
-    # List of argument combinations to-be-tested
-    # Each element is a separate test case
-    # Each element is unpacked as the arguments for that test case
-    args_list: list[Union[tuple[int, ...], int]]
-
-    # All functions called by `func`
-    helpers: list[FunctionType]
-
-    # Optimization levels to-be-tested
-    opti_levels: list[int] = dataclasses.field(default_factory=lambda: [0, 1, 2, 4, 8])
-
-    # This results in `len(args_list) * len(opti_levels)` test cases
 
 
 class BaseTestWrapper:

--- a/tests/integration/base_tests.py
+++ b/tests/integration/base_tests.py
@@ -186,6 +186,8 @@ class BaseTestWrapper:
         ):
             """
             Performance test
+            Does max-clock cycle checks
+            The caller is always ready to receive data
             """
             self.__test(funcs, test_cases, CodegenConfig(random_ready=False))
 
@@ -196,6 +198,7 @@ class BaseTestWrapper:
         ):
             """
             Correctness test
+            The caller is not always ready to receive data
             """
             self.__test(funcs, test_cases, CodegenConfig(random_ready=True))
 

--- a/tests/integration/base_tests.py
+++ b/tests/integration/base_tests.py
@@ -45,7 +45,7 @@ class BaseTestWrapper:
             """
             Root test function
             """
-            funcs = [test_param.func]
+            funcs = [test_param.func] + test_param.helpers
             test_cases = test_param.args_list
 
             if self.args.first_test:

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -10,15 +10,34 @@ from .functions import *
 from .utils import Parameters, name_func
 
 PARAMETERS = [
-    Parameters(func=multi_funcs, helpers=[multiplier, p2vrange], args_list=[(13, 17)]),
     Parameters(
-        func=fib_product, helpers=[multiplier, fib, p2vrange], args_list=[10, 20]
+        func=multi_funcs,
+        helpers=[multiplier, p2vrange],
+        args_list=[(13, 17)],
     ),
-    Parameters(func=fib, helpers=[p2vrange], args_list=range(10, 31, 10)),
     Parameters(
-        func=quad_multiply, helpers=[multiplier_generator], args_list=[(3, 7), (31, 43)]
+        func=fib_product,
+        helpers=[multiplier, fib, p2vrange],
+        args_list=[10, 20],
     ),
-    Parameters(func=double_for, helpers=[p2vrange], args_list=[5, 10, 15, 20]),
+    Parameters(
+        func=fib,
+        helpers=[p2vrange],
+        args_list=range(10, 31, 10),
+    ),
+    Parameters(
+        func=quad_multiply,
+        helpers=[multiplier_generator],
+        args_list=[
+            (3, 7),
+            (31, 43),
+        ],
+    ),
+    Parameters(
+        func=double_for,
+        helpers=[p2vrange],
+        args_list=[5, 10, 15, 20],
+    ),
     Parameters(
         func=dupe,
         helpers=[p2vrange],

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -19,7 +19,11 @@ PARAMETERS = [
         func=quad_multiply, helpers=[multiplier_generator], args_list=[(3, 7), (31, 43)]
     ),
     Parameters(func=double_for, helpers=[p2vrange], args_list=[5, 10, 15, 20]),
-    Parameters(func=dupe, helpers=[p2vrange], args_list=[(0, 10, 1), (3, 73, 7)]),
+    Parameters(
+        func=dupe,
+        helpers=[p2vrange],
+        args_list=[(0, 10, 1), (3, 73, 7)],
+    ),
     Parameters(
         func=olympic_logo_naive,
         helpers=[circle_lines],

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -2,54 +2,53 @@
 Test suite for functions that call other functions
 """
 
-
 import pytest
 from parameterized import parameterized
 
 from .base_tests import BaseTestWrapper
 from .functions import *
-from .utils import name_func
+from .utils import Parameters, name_func
 
 PARAMETERS = [
-    ([multi_funcs, multiplier, p2vrange], [(13, 17)]),
-    ([fib_product, multiplier, fib, p2vrange], [10, 20]),
-    ([fib_product, multiplier, fib, p2vrange], [10, 20]),
-    ([fib, p2vrange], range(10, 31, 10)),
-    ([quad_multiply, multiplier_generator], [(3, 7), (31, 43)]),
-    ([double_for, p2vrange], [5, 10, 15, 20]),
-    ([dupe, p2vrange], [(0, 10, 1), (3, 73, 7)]),
-    ([olympic_logo_naive, circle_lines], [(10, 10, 4), (13, 13, 7)]),
-    (
-        [olympic_logo, olympic_logo_mids, circle_lines],
-        [(10, 10, 4), (13, 13, 7)],
+    Parameters(func=multi_funcs, helpers=[multiplier, p2vrange], args_list=[(13, 17)]),
+    Parameters(
+        func=fib_product, helpers=[multiplier, fib, p2vrange], args_list=[10, 20]
+    ),
+    Parameters(func=fib, helpers=[p2vrange], args_list=range(10, 31, 10)),
+    Parameters(
+        func=quad_multiply, helpers=[multiplier_generator], args_list=[(3, 7), (31, 43)]
+    ),
+    Parameters(func=double_for, helpers=[p2vrange], args_list=[5, 10, 15, 20]),
+    Parameters(func=dupe, helpers=[p2vrange], args_list=[(0, 10, 1), (3, 73, 7)]),
+    Parameters(
+        func=olympic_logo_naive,
+        helpers=[circle_lines],
+        args_list=[(10, 10, 4), (13, 13, 7)],
+    ),
+    Parameters(
+        func=olympic_logo,
+        helpers=[olympic_logo_mids, circle_lines],
+        args_list=[(10, 10, 4), (13, 13, 7)],
     ),
 ]
 
 
-# @pytest.mark.usefixtures("argparse")
-# class TestMulti(BaseTestWrapper.BaseTest):
-#     @parameterized.expand(
-#         input=PARAMETERS,
-#         name_func=name_func,
-#     )
-#     def test_perf(
-#         self,
-#         funcs: Iterable[FunctionType],
-#         test_cases: Iterable[Union[tuple[int, ...], int]],
-#     ):
-#         BaseTestWrapper.BaseTest.test_perf(self, funcs, test_cases)
+@pytest.mark.usefixtures("argparse")
+class TestMulti(BaseTestWrapper.BaseTest):
+    @parameterized.expand(
+        input=PARAMETERS,
+        name_func=name_func,
+    )
+    def test_perf(self, test_param: Parameters):
+        BaseTestWrapper.BaseTest.test_perf(self, test_param)
 
-#     @parameterized.expand(
-#         input=PARAMETERS,
-#         name_func=name_func,
-#     )
-#     def test_correct(
-#         self,
-#         funcs: Iterable[FunctionType],
-#         test_cases: Iterable[Union[tuple[int, ...], int]],
-#     ):
-#         BaseTestWrapper.BaseTest.test_correct(self, funcs, test_cases)
+    @parameterized.expand(
+        input=PARAMETERS,
+        name_func=name_func,
+    )
+    def test_correct(self, test_param: Parameters):
+        BaseTestWrapper.BaseTest.test_correct(self, test_param)
 
-#     @classmethod
-#     def tearDownClass(cls):
-#         BaseTestWrapper.BaseTest.make_statistics(cls)
+    @classmethod
+    def tearDownClass(cls):
+        BaseTestWrapper.BaseTest.make_statistics(cls)

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -2,8 +2,6 @@
 Test suite for functions that call other functions
 """
 
-from types import FunctionType
-from typing import Iterable, Union
 
 import pytest
 from parameterized import parameterized
@@ -28,30 +26,30 @@ PARAMETERS = [
 ]
 
 
-@pytest.mark.usefixtures("argparse")
-class TestMulti(BaseTestWrapper.BaseTest):
-    @parameterized.expand(
-        input=PARAMETERS,
-        name_func=name_func,
-    )
-    def test_perf(
-        self,
-        funcs: Iterable[FunctionType],
-        test_cases: Iterable[Union[tuple[int, ...], int]],
-    ):
-        BaseTestWrapper.BaseTest.test_perf(self, funcs, test_cases)
+# @pytest.mark.usefixtures("argparse")
+# class TestMulti(BaseTestWrapper.BaseTest):
+#     @parameterized.expand(
+#         input=PARAMETERS,
+#         name_func=name_func,
+#     )
+#     def test_perf(
+#         self,
+#         funcs: Iterable[FunctionType],
+#         test_cases: Iterable[Union[tuple[int, ...], int]],
+#     ):
+#         BaseTestWrapper.BaseTest.test_perf(self, funcs, test_cases)
 
-    @parameterized.expand(
-        input=PARAMETERS,
-        name_func=name_func,
-    )
-    def test_correct(
-        self,
-        funcs: Iterable[FunctionType],
-        test_cases: Iterable[Union[tuple[int, ...], int]],
-    ):
-        BaseTestWrapper.BaseTest.test_correct(self, funcs, test_cases)
+#     @parameterized.expand(
+#         input=PARAMETERS,
+#         name_func=name_func,
+#     )
+#     def test_correct(
+#         self,
+#         funcs: Iterable[FunctionType],
+#         test_cases: Iterable[Union[tuple[int, ...], int]],
+#     ):
+#         BaseTestWrapper.BaseTest.test_correct(self, funcs, test_cases)
 
-    @classmethod
-    def tearDownClass(cls):
-        BaseTestWrapper.BaseTest.make_statistics(cls)
+#     @classmethod
+#     def tearDownClass(cls):
+#         BaseTestWrapper.BaseTest.make_statistics(cls)

--- a/tests/integration/test_single.py
+++ b/tests/integration/test_single.py
@@ -21,7 +21,11 @@ PARAMETERS = [
     Parameters(func=happy_face, args_list=[(50, 51, 7), (76, 97, 43)]),
     Parameters(func=rectangle_filled, args_list=[(32, 84, 5, 7), (64, 78, 23, 27)]),
     Parameters(func=rectangle_lines, args_list=[(32, 84, 5, 7), (84, 96, 46, 89)]),
-    Parameters(func=floating_point_add, args_list=[(0, 127, 0, 0, 128, 0)]),  # 1 + 2
+    Parameters(
+        func=floating_point_add,
+        args_list=[(0, 127, 0, 0, 128, 0)],
+        opti_levels=Parameters.zero_and_exp2s(2),
+    ),  # 1 + 2
 ]
 
 

--- a/tests/integration/test_single.py
+++ b/tests/integration/test_single.py
@@ -2,7 +2,6 @@
 Test suite for basic functions
 """
 
-
 import pytest
 from parameterized import parameterized
 

--- a/tests/integration/test_single.py
+++ b/tests/integration/test_single.py
@@ -10,22 +10,55 @@ from .functions import *
 from .utils import Parameters, name_func
 
 PARAMETERS = [
-    Parameters(func=keyword_test, args_list=[()]),
-    Parameters(func=floor_div, args_list=[13, 23]),
-    Parameters(func=operators, args_list=[(31, 13), (-31, 13), (31, -13), (-31, -13)]),
-    Parameters(func=multiplier_generator, args_list=[(13, 17), (78, 67), (15, -12)]),
-    Parameters(func=multiplier, args_list=[(13, 17), (78, 67), (15, -12)]),
-    Parameters(func=p2vrange, args_list=[(0, 10, 1), (0, 1000, 1)]),
-    Parameters(func=division, args_list=[(6, 7, 10), (2, 3, 30), (13, 17, 5)]),
-    Parameters(func=circle_lines, args_list=[(21, 37, 7), (79, 45, 43)]),
-    Parameters(func=happy_face, args_list=[(50, 51, 7), (76, 97, 43)]),
-    Parameters(func=rectangle_filled, args_list=[(32, 84, 5, 7), (64, 78, 23, 27)]),
-    Parameters(func=rectangle_lines, args_list=[(32, 84, 5, 7), (84, 96, 46, 89)]),
+    Parameters(
+        func=keyword_test,
+        args_list=[()],
+    ),
+    Parameters(
+        func=floor_div,
+        args_list=[13, 23],
+    ),
+    Parameters(
+        func=operators,
+        args_list=[(31, 13), (-31, 13), (31, -13), (-31, -13)],
+    ),
+    Parameters(
+        func=multiplier_generator,
+        args_list=[(13, 17), (78, 67), (15, -12)],
+    ),
+    Parameters(
+        func=multiplier,
+        args_list=[(13, 17), (78, 67), (15, -12)],
+    ),
+    Parameters(
+        func=p2vrange,
+        args_list=[(0, 10, 1), (0, 1000, 1)],
+    ),
+    Parameters(
+        func=division,
+        args_list=[(6, 7, 10), (2, 3, 30), (13, 17, 5)],
+    ),
+    Parameters(
+        func=circle_lines,
+        args_list=[(21, 37, 7), (79, 45, 43)],
+    ),
+    Parameters(
+        func=happy_face,
+        args_list=[(50, 51, 7), (76, 97, 43)],
+    ),
+    Parameters(
+        func=rectangle_filled,
+        args_list=[(32, 84, 5, 7), (64, 78, 23, 27)],
+    ),
+    Parameters(
+        func=rectangle_lines,
+        args_list=[(32, 84, 5, 7), (84, 96, 46, 89)],
+    ),
     Parameters(
         func=floating_point_add,
-        args_list=[(0, 127, 0, 0, 128, 0)],
+        args_list=[(0, 127, 0, 0, 128, 0)],  # 1 + 3
         opti_levels=Parameters.zero_and_exp2s(2),
-    ),  # 1 + 2
+    ),
 ]
 
 

--- a/tests/integration/test_single.py
+++ b/tests/integration/test_single.py
@@ -35,8 +35,9 @@ class TestSingle(BaseTestWrapper.BaseTest):
         name_func=name_func,
     )
     def test_perf(
-        self, funcs: list[FunctionType], test_cases: list[Union[tuple[int, ...], int]]
+        self, funcs: FunctionType, test_cases: list[Union[tuple[int, ...], int]]
     ):
+        funcs = [funcs]
         BaseTestWrapper.BaseTest.test_perf(self, funcs, test_cases)
 
     @parameterized.expand(
@@ -44,8 +45,9 @@ class TestSingle(BaseTestWrapper.BaseTest):
         name_func=name_func,
     )
     def test_correct(
-        self, funcs: list[FunctionType], test_cases: list[Union[tuple[int, ...], int]]
+        self, funcs: FunctionType, test_cases: list[Union[tuple[int, ...], int]]
     ):
+        funcs = [funcs]
         BaseTestWrapper.BaseTest.test_correct(self, funcs, test_cases)
 
     @classmethod

--- a/tests/integration/test_single.py
+++ b/tests/integration/test_single.py
@@ -2,29 +2,27 @@
 Test suite for basic functions
 """
 
-from types import FunctionType
-from typing import Union
 
 import pytest
 from parameterized import parameterized
 
 from .base_tests import BaseTestWrapper
 from .functions import *
-from .utils import name_func
+from .utils import Parameters, name_func
 
 PARAMETERS = [
-    (keyword_test, [()]),
-    (floor_div, [13, 23]),
-    (operators, [(31, 13), (-31, 13), (31, -13), (-31, -13)]),
-    (multiplier_generator, [(13, 17), (78, 67), (15, -12)]),
-    (multiplier, [(13, 17), (78, 67), (15, -12)]),
-    (p2vrange, [(0, 10, 1), (0, 1000, 1)]),
-    (division, [(6, 7, 10), (2, 3, 30), (13, 17, 5)]),
-    (circle_lines, [(21, 37, 7), (79, 45, 43)]),
-    (happy_face, [(50, 51, 7), (76, 97, 43)]),
-    (rectangle_filled, [(32, 84, 5, 7), (64, 78, 23, 27)]),
-    (rectangle_lines, [(32, 84, 5, 7), (84, 96, 46, 89)]),
-    (floating_point_add, [(0, 127, 0, 0, 128, 0)]),  # 1 + 2
+    Parameters(func=keyword_test, args_list=[()]),
+    Parameters(func=floor_div, args_list=[13, 23]),
+    Parameters(func=operators, args_list=[(31, 13), (-31, 13), (31, -13), (-31, -13)]),
+    Parameters(func=multiplier_generator, args_list=[(13, 17), (78, 67), (15, -12)]),
+    Parameters(func=multiplier, args_list=[(13, 17), (78, 67), (15, -12)]),
+    Parameters(func=p2vrange, args_list=[(0, 10, 1), (0, 1000, 1)]),
+    Parameters(func=division, args_list=[(6, 7, 10), (2, 3, 30), (13, 17, 5)]),
+    Parameters(func=circle_lines, args_list=[(21, 37, 7), (79, 45, 43)]),
+    Parameters(func=happy_face, args_list=[(50, 51, 7), (76, 97, 43)]),
+    Parameters(func=rectangle_filled, args_list=[(32, 84, 5, 7), (64, 78, 23, 27)]),
+    Parameters(func=rectangle_lines, args_list=[(32, 84, 5, 7), (84, 96, 46, 89)]),
+    Parameters(func=floating_point_add, args_list=[(0, 127, 0, 0, 128, 0)]),  # 1 + 2
 ]
 
 
@@ -34,21 +32,15 @@ class TestSingle(BaseTestWrapper.BaseTest):
         input=PARAMETERS,
         name_func=name_func,
     )
-    def test_perf(
-        self, funcs: FunctionType, test_cases: list[Union[tuple[int, ...], int]]
-    ):
-        funcs = [funcs]
-        BaseTestWrapper.BaseTest.test_perf(self, funcs, test_cases)
+    def test_perf(self, test_param: Parameters):
+        BaseTestWrapper.BaseTest.test_perf(self, test_param)
 
     @parameterized.expand(
         input=PARAMETERS,
         name_func=name_func,
     )
-    def test_correct(
-        self, funcs: FunctionType, test_cases: list[Union[tuple[int, ...], int]]
-    ):
-        funcs = [funcs]
-        BaseTestWrapper.BaseTest.test_correct(self, funcs, test_cases)
+    def test_correct(self, test_param: Parameters):
+        BaseTestWrapper.BaseTest.test_correct(self, test_param)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -3,8 +3,9 @@ Utilities for integration tests
 """
 
 import dataclasses
+import itertools
 from types import FunctionType
-from typing import Union
+from typing import Iterator, Union
 
 
 def make_tuple(input: Union[int, tuple[int, ...]]) -> tuple[int, ...]:
@@ -42,7 +43,25 @@ class Parameters:
 
     # Optimization levels to-be-tested
     opti_levels: list[int] = dataclasses.field(
-        default_factory=lambda: [0, 1, 2, 4, 8, 16]
+        default_factory=lambda: Parameters.zero_and_exp2s(16)
     )
 
     # This results in `len(args_list) * len(opti_levels)` test cases
+
+    @staticmethod
+    def _exp2s(high: int) -> Iterator[int]:
+        """
+        Iterates over the exp2, until result is >= high
+        """
+        for i in itertools.count():
+            val = 2**i
+            yield val
+            if val >= high:
+                return
+
+    @staticmethod
+    def zero_and_exp2s(high: int) -> list[int]:
+        """
+        Returns a list of [0, 1, 2, 4, ..., high], where each element except first is a power of 2
+        """
+        return [0] + list(Parameters._exp2s(high))

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -5,7 +5,9 @@ Utilities for integration tests
 import dataclasses
 import itertools
 from types import FunctionType
-from typing import Iterator, Union
+from typing import Iterator, Union, cast
+
+from parameterized import param, parameterized
 
 
 def make_tuple(input: Union[int, tuple[int, ...]]) -> tuple[int, ...]:
@@ -17,15 +19,16 @@ def make_tuple(input: Union[int, tuple[int, ...]]) -> tuple[int, ...]:
     return input
 
 
-def name_func(testcase_func: FunctionType, _: int, param: dict) -> str:
+def name_func(testcase_func: FunctionType, _param_num: int, param: param) -> str:
     """
-    Custom name function
+    Custom name function for test case naming with the parameterized package
 
     Stores in _testMethodName
     """
-    # assert False, f"{param=} {param[0][0]=}"
-    test_param = param[0][0]
-    return f"{testcase_func.__name__}::{test_param.func.__name__}"
+    test_param = cast(Parameters, param.args[0])
+    return parameterized.to_safe_name(
+        f"{testcase_func.__name__}::{test_param.func.__name__}"
+    )
 
 
 @dataclasses.dataclass

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,3 +1,8 @@
+"""
+Utilities for integration tests
+"""
+
+import dataclasses
 from types import FunctionType
 from typing import Union
 
@@ -22,3 +27,22 @@ def name_func(testcase_func: FunctionType, _: int, param: dict) -> str:
     else:
         # If given list of funcs, use first for naming
         return f"{testcase_func.__name__}::{param.args[0][0].__name__}"
+
+
+@dataclasses.dataclass
+class TestParameters:
+    # Function to-be-tested
+    func: FunctionType
+
+    # List of argument combinations to-be-tested
+    # Each element is a separate test case
+    # Each element is unpacked as the arguments for that test case
+    args_list: list[Union[tuple[int, ...], int]]
+
+    # All functions called by `func`
+    helpers: list[FunctionType]
+
+    # Optimization levels to-be-tested
+    opti_levels: list[int] = dataclasses.field(default_factory=lambda: [0, 1, 2, 4, 8])
+
+    # This results in `len(args_list) * len(opti_levels)` test cases

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -22,15 +22,13 @@ def name_func(testcase_func: FunctionType, _: int, param: dict) -> str:
 
     Stores in _testMethodName
     """
-    if isinstance(param.args[0], FunctionType):
-        return f"{testcase_func.__name__}::{param.args[0].__name__}"
-    else:
-        # If given list of funcs, use first for naming
-        return f"{testcase_func.__name__}::{param.args[0][0].__name__}"
+    # assert False, f"{param=} {param[0][0]=}"
+    test_param = param[0][0]
+    return f"{testcase_func.__name__}::{test_param.func.__name__}"
 
 
 @dataclasses.dataclass
-class TestParameters:
+class Parameters:
     # Function to-be-tested
     func: FunctionType
 
@@ -40,7 +38,7 @@ class TestParameters:
     args_list: list[Union[tuple[int, ...], int]]
 
     # All functions called by `func`
-    helpers: list[FunctionType]
+    helpers: list[FunctionType] = dataclasses.field(default_factory=list)
 
     # Optimization levels to-be-tested
     opti_levels: list[int] = dataclasses.field(default_factory=lambda: [0, 1, 2, 4, 8])

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -41,6 +41,8 @@ class Parameters:
     helpers: list[FunctionType] = dataclasses.field(default_factory=list)
 
     # Optimization levels to-be-tested
-    opti_levels: list[int] = dataclasses.field(default_factory=lambda: [0, 1, 2, 4, 8])
+    opti_levels: list[int] = dataclasses.field(
+        default_factory=lambda: [0, 1, 2, 4, 8, 16]
+    )
 
     # This results in `len(args_list) * len(opti_levels)` test cases


### PR DESCRIPTION
Resolves #57 

- Consolidates arguments into a new class
- Enables specifying optimization level for each test case in source code
- Changes pytest CLI argument to be a limit on optimization levels being tested