### PR TITLE
Add support for calling functions that return literals

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -1,5 +1,9 @@
 use tohdl_ir::graph::CFG;
 
+fn code_to_graph(code: &str) -> CFG {
+    tohdl_frontend::AstVisitor::from_text(code).get_graph()
+}
+
 pub fn aug_assign_str() -> &'static str {
     r#"
 def aug_assign(a, b):
@@ -9,12 +13,7 @@ def aug_assign(a, b):
 }
 
 pub fn aug_assign_graph() -> CFG {
-    let code = aug_assign_str();
-    let visitor = tohdl_frontend::AstVisitor::from_text(code);
-
-    let graph = visitor.get_graph();
-
-    graph
+    code_to_graph(aug_assign_str())
 }
 
 pub fn func_call_str() -> &'static str {
@@ -22,15 +21,22 @@ pub fn func_call_str() -> &'static str {
 def func_call(a):
     c = 3
     b = aug_assign(a, c)
-    return b
+    d = return_literal()
+    return b + d
 "#
 }
 
 pub fn func_call_graph() -> CFG {
-    let code = func_call_str();
-    let visitor = tohdl_frontend::AstVisitor::from_text(code);
+    code_to_graph(func_call_str())
+}
 
-    let graph = visitor.get_graph();
+pub fn return_literal_str() -> &'static str {
+    r#"
+def return_literal():
+    return 3
+"#
+}
 
-    graph
+pub fn return_literal_graph() -> CFG {
+    code_to_graph(return_literal_str())
 }

--- a/crates/tests/tests/function_call.rs
+++ b/crates/tests/tests/function_call.rs
@@ -7,7 +7,7 @@ use tohdl_passes::{
     transform::{BraunEtAl, InsertCallNodes, InsertFuncNodes},
     Transform,
 };
-use tohdl_tests::{aug_assign_str, func_call_str};
+use tohdl_tests::{aug_assign_str, func_call_str, return_literal_str};
 
 fn aug_assign_graph() -> CFG {
     let mut graph = tohdl_tests::aug_assign_graph();
@@ -35,6 +35,7 @@ fn func_call() {
         functions: BTreeMap::from([
             ("func_call".into(), func_call_str().into()),
             ("aug_assign".into(), aug_assign_str().into()),
+            ("return_literal".into(), return_literal_str().into()),
         ])
         .into(),
     };

--- a/tests/integration/functions.py
+++ b/tests/integration/functions.py
@@ -573,7 +573,7 @@ def fib_to_7_seg(n):
 
 def callee(a: int, b: int) -> int:
     c = a + b
-    return c
+    return 5
 
 
 def caller(a: int, n: int):


### PR DESCRIPTION
Previously
```python
def func():
    return 5
```
is not convertible with Rust backend and would have to be rewritten with a temp var. Now it is.